### PR TITLE
Add rules and tidy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codat",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Client Library for Codat accounting data API",
   "main": "codat.js",
   "scripts": {
@@ -44,7 +44,9 @@
       "it",
       "describe",
       "beforeEach",
-      "API_CLIENT"
+      "API_CLIENT",
+      "should",
+      "uat"
     ]
   }
 }

--- a/src/codat-commands.js
+++ b/src/codat-commands.js
@@ -1,0 +1,43 @@
+
+class CodatCreateCommand {
+  constructor (companyId) {
+    this.companyId = companyId
+  }
+
+  generateModel () { throw new Error('generateModel is abstract') }
+  getResource () { throw new Error('getResource is abstract') }
+
+  run (apiClient) {
+    return apiClient.companyDataClient(this.companyId).post(this.getResource(), null, this.generateModel())
+  }
+}
+exports.CodatCreateCommand = CodatCreateCommand
+
+class CodatUpdateCommand {
+  constructor (companyId, entityId) {
+    this.companyId = companyId
+    this.entityId = entityId
+  }
+
+  generateModel () { throw new Error('generateModel is abstract') }
+  getResource () { throw new Error('getResource is abstract') }
+
+  run (apiClient) {
+    return apiClient.companyDataClient(this.companyId).put(`${this.getResource()}/${this.entityId}`, null, this.generateModel())
+  }
+}
+exports.CodatUpdateCommand = CodatUpdateCommand
+
+class CodatDeleteCommand {
+  constructor (companyId, entityId) {
+    this.companyId = companyId
+    this.entityId = entityId
+  }
+
+  getResource () { throw new Error('getResource is abstract') }
+
+  run (apiClient) {
+    return apiClient.companyDataClient(this.companyId).delete(`${this.getResource()}/${this.entityId}`, null)
+  }
+}
+exports.CodatDeleteCommand = CodatDeleteCommand

--- a/src/codat-queries.js
+++ b/src/codat-queries.js
@@ -1,8 +1,33 @@
-const constants = require('./codat').constants
+
+const constants = {
+  BALANCE_SHEET: 'financials/balanceSheet',
+  BILLS: 'bills',
+  CHART_OF_ACCOUNTS: 'accounts',
+  CREDIT_NOTES: 'creditNotes',
+  CUSTOMERS: 'customers',
+  INVOICES: 'invoices',
+  PAYMENTS: 'payments',
+  PROFIT_AND_LOSS: 'financials/profitAndLoss',
+  SUPPLIERS: 'suppliers',
+  BANK_STATEMENTS: 'bankStatements',
+  COMPANY: 'info'
+}
+exports.constants = constants
 
 // Query company
 class CodatQuery {
+  generateArgs () { throw new Error('generateArgs is abstract') }
+  getResource () { throw new Error('getResource is abstract') }
+
+  run (apiClient) {
+    return apiClient.__companyClient().get(this.getResource(), this.generateArgs())
+  }
+}
+exports.CodatQuery = CodatQuery
+
+class CodatDataQuery extends CodatQuery {
   constructor (companyId) {
+    super()
     this.companyId = companyId
   }
 
@@ -14,7 +39,7 @@ class CodatQuery {
   }
 }
 
-class FinancialQuery extends CodatQuery {
+class FinancialQuery extends CodatDataQuery {
   constructor (companyId, periodLength, periodsToCompare, startMonth) {
     super(companyId)
     this.periodLength = periodLength
@@ -33,19 +58,19 @@ class FinancialQuery extends CodatQuery {
 
 class BalanceSheetQuery extends FinancialQuery {
   getResource () {
-    return constants.datasets.BALANCE_SHEET
+    return constants.BALANCE_SHEET
   }
 }
 exports.BalanceSheetQuery = BalanceSheetQuery
 
 class ProfitAndLossQuery extends FinancialQuery {
   getResource () {
-    return constants.datasets.PROFIT_AND_LOSS
+    return constants.PROFIT_AND_LOSS
   }
 }
 exports.ProfitAndLossQuery = ProfitAndLossQuery
 
-class FlexibleQuery extends CodatQuery {
+class FlexibleQuery extends CodatDataQuery {
   constructor (companyId, queryString) {
     super(companyId)
     this.queryString = queryString
@@ -74,46 +99,46 @@ class FlexiblePagedQuery extends FlexibleQuery {
   }
 }
 
-class AccountsQuery extends CodatQuery {
+class AccountsQuery extends CodatDataQuery {
   generateArgs () {
     return { }
   }
 
   getResource () {
-    return constants.datasets.CHART_OF_ACCOUNTS
+    return constants.CHART_OF_ACCOUNTS
   }
 }
 exports.AccountsQuery = AccountsQuery
 
 class BillsQuery extends FlexiblePagedQuery {
   getResource () {
-    return constants.datasets.BILLS
+    return constants.BILLS
   }
 }
 exports.BillsQuery = BillsQuery
 
 class CreditNotesQuery extends FlexiblePagedQuery {
   getResource () {
-    return constants.datasets.CREDIT_NOTES
+    return constants.CREDIT_NOTES
   }
 }
 exports.CreditNotesQuery = CreditNotesQuery
 
 class InvoicesQuery extends FlexiblePagedQuery {
   getResource () {
-    return constants.datasets.INVOICES
+    return constants.INVOICES
   }
 }
 exports.InvoicesQuery = InvoicesQuery
 
-class InvoicePdfQuery extends CodatQuery {
+class InvoicePdfQuery extends CodatDataQuery {
   constructor (companyId, invoiceId) {
     super(companyId)
     this.invoiceId = invoiceId
   }
 
   getResource () {
-    return `${constants.datasets.INVOICES}/${this.invoiceId}/pdf`
+    return `${constants.INVOICES}/${this.invoiceId}/pdf`
   }
 
   generateArgs () {
@@ -124,28 +149,28 @@ exports.InvoicePdfQuery = InvoicePdfQuery
 
 class CustomersQuery extends FlexiblePagedQuery {
   getResource () {
-    return constants.datasets.CUSTOMERS
+    return constants.CUSTOMERS
   }
 }
 exports.CustomersQuery = CustomersQuery
 
 class SuppliersQuery extends FlexiblePagedQuery {
   getResource () {
-    return constants.datasets.SUPPLIERS
+    return constants.SUPPLIERS
   }
 }
 exports.SuppliersQuery = SuppliersQuery
 
 class PaymentsQuery extends FlexiblePagedQuery {
   getResource () {
-    return constants.datasets.PAYMENTS
+    return constants.PAYMENTS
   }
 }
 exports.PaymentsQuery = PaymentsQuery
 
-class CompanyQuery extends CodatQuery {
+class CompanyQuery extends CodatDataQuery {
   getResource () {
-    return constants.datasets.COMPANY
+    return constants.COMPANY
   }
 
   generateArgs () {
@@ -156,7 +181,7 @@ exports.CompanyQuery = CompanyQuery
 
 class BankStatementsQuery extends FlexiblePagedQuery {
   getResource () {
-    return constants.datasets.BANK_STATEMENTS
+    return constants.BANK_STATEMENTS
   }
 }
 exports.BankStatementsQuery = BankStatementsQuery

--- a/src/codat-refresh.js
+++ b/src/codat-refresh.js
@@ -1,4 +1,10 @@
-const constants = require('./codat').constants
+const dataSetConstants = require('./codat-queries').constants
+
+const constants = {
+  ALL: 'all',
+  QUEUE: 'queue'
+}
+exports.constants = constants
 
 /// Sync company.
 
@@ -15,7 +21,7 @@ class CodatSync {
 }
 
 class RefreshAllDatasets extends CodatSync {
-  getResource () { return constants.refresh.ALL }
+  getResource () { return constants.ALL }
 }
 exports.RefreshAllDatasets = RefreshAllDatasets
 
@@ -23,9 +29,9 @@ class RefreshDataset extends CodatSync {
   constructor (companyId, datasetName) {
     super(companyId)
     // BUG: naming for api and datatype is different.
-    this.datasetName = datasetName === constants.datasets.COMPANY ? 'company' : datasetName
+    this.datasetName = datasetName === dataSetConstants.COMPANY ? 'company' : datasetName
   }
 
-  getResource () { return `${constants.refresh.QUEUE}/${this.datasetName}` }
+  getResource () { return `${constants.QUEUE}/${this.datasetName}` }
 }
 exports.RefreshDataset = RefreshDataset

--- a/src/codat-rules.js
+++ b/src/codat-rules.js
@@ -1,0 +1,213 @@
+const queries = require('./codat-queries')
+const commands = require('./codat-commands')
+
+const constants = {
+  RULES: 'rules',
+  RULE_WITHID: (ruleId) => `${constants.RULES}/${ruleId}`,
+  ALERTS: 'rules/alerts',
+  ALERT_WITHID: (alertId) => `${constants.RULES}/alerts/${alertId}`,
+  ALERTS_FORRULE: (ruleId) => `${constants.RULE_WITHID(ruleId)}/alerts`,
+  DEFAULT_GUID: '00000000-0000-0000-0000-000000000000'
+}
+exports.constants = constants
+
+const COMPARISONS = {
+  GT: '>',
+  LT: '<'
+}
+exports.COMPARISONS = COMPARISONS
+
+// RULE QUERIES
+
+class BaseRulesQuery extends queries.CodatQuery {
+  generateArgs () {
+    return { }
+  }
+}
+
+class RulesQuery extends BaseRulesQuery {
+  getResource () {
+    return constants.RULES
+  }
+}
+exports.RulesQuery = RulesQuery
+
+class RuleQuery extends BaseRulesQuery {
+  constructor (ruleId) {
+    super()
+    this.ruleId = ruleId
+  }
+
+  getResource () {
+    return constants.RULE_WITHID(this.ruleId)
+  }
+}
+exports.RuleQuery = RuleQuery
+
+class AlertsQuery extends BaseRulesQuery {
+  getResource () {
+    return constants.ALERTS
+  }
+}
+exports.AlertsQuery = AlertsQuery
+
+class AlertQuery extends BaseRulesQuery {
+  constructor (alertId) {
+    super()
+    this.alertId = alertId
+  }
+
+  getResource () {
+    return constants.ALERT_WITHID(this.alertId)
+  }
+}
+exports.AlertQuery = AlertQuery
+
+class AlertsForRuleQuery extends BaseRulesQuery {
+  constructor (ruleId) {
+    super()
+    this.ruleId = ruleId
+  }
+
+  getResource () {
+    return constants.ALERTS_FORRULE(this.ruleId)
+  }
+}
+exports.AlertsForRuleQuery = AlertsForRuleQuery
+
+// RULE COMMANDS
+
+class CodatRuleOptions {
+  constructor (companyId, emails, webhook) {
+    this.companyId = companyId
+    this.emails = emails
+    this.webhook = webhook
+  }
+
+  static create () {
+    return new CodatRuleOptions()
+  }
+
+  withCompany (companyId) {
+    return new CodatRuleOptions(companyId, this.emails, this.webhook)
+  }
+
+  withEmail (email) {
+    if (this.emails && this.emails.indexOf(email) > -1) {
+      return this
+    }
+
+    const emails = this.emails || []
+    emails.push(email)
+    return new CodatRuleOptions(this.companyId, emails, this.webhook)
+  }
+
+  withWebHook (webhook) {
+    return new CodatRuleOptions(this.companyId, this.emails, webhook)
+  }
+}
+exports.CodatRuleOptions = CodatRuleOptions
+
+class CodatRule {
+  constructor (options) {
+    if (options && !(options instanceof CodatRuleOptions)) {
+      throw new Error('Options must be of type CodatRuleOptions')
+    }
+
+    if (options) {
+      this.companyId = options.companyId || null
+      this.emails = options.emails || null
+      this.webhook = options.webhook || null
+    }
+  }
+
+  toModel () { throw new Error('generateModel is abstract') }
+}
+exports.CodatRule = CodatRule
+
+// Data sync completed
+class DataSyncCompleteRule extends CodatRule {
+  toModel () {
+    return {
+      companyId: this.companyId,
+      type: 'Data sync completed',
+      emails: this.emails,
+      webhook: this.webhook
+    }
+  }
+}
+exports.DataSyncCompleteRule = DataSyncCompleteRule
+
+class NewCompanySynchronised extends CodatRule {
+  toModel () {
+    return {
+      companyId: this.companyId,
+      type: 'New company synchronised',
+      emails: this.emails,
+      webhook: this.webhook
+    }
+  }
+}
+exports.NewCompanySynchronised = NewCompanySynchronised
+
+class ComparisonRule extends CodatRule {
+  constructor (options, comparison, ratioLimit) {
+    super(options)
+
+    this.comparison = comparison || '>'
+    if (this.isValidComparison(this.comparison) === false) {
+      throw new Error('Valid comparions are only < and >')
+    }
+
+    this.ratioLimit = ratioLimit || 0
+  }
+
+  isValidComparison (comparison) {
+    return comparison === COMPARISONS.LT || comparison === COMPARISONS.GT
+  }
+}
+
+class CurrentAssetsCurrentLiabilitiesRatioRule extends ComparisonRule {
+  toModel () {
+    return {
+      companyId: this.companyId,
+      type: `CurrentAssetsCurrentLiabilitiesRatio(${this.comparison},${this.ratioLimit})`,
+      emails: this.emails,
+      webhook: this.webhook
+    }
+  }
+}
+exports.CurrentAssetsCurrentLiabilitiesRatioRule = CurrentAssetsCurrentLiabilitiesRatioRule
+
+class DebtorsOutstandingLoanOutstandingRatioRule extends ComparisonRule {
+  toModel () {
+    return {
+      companyId: this.companyId,
+      type: `DebtorsOutstandingLoanOutstandingRatio(${this.comparison},${this.ratioLimit})`,
+      emails: this.emails,
+      webhook: this.webhook
+    }
+  }
+}
+exports.DebtorsOutstandingLoanOutstandingRatioRule = DebtorsOutstandingLoanOutstandingRatioRule
+
+class AddRuleCommand extends commands.CodatCreateCommand {
+  constructor (type) {
+    super()
+
+    if (!(type instanceof CodatRule)) {
+      throw new Error('type must be of type CodatRule')
+    }
+
+    this.type = type
+  }
+
+  generateModel () {
+    return this.type.toModel()
+  }
+
+  getResource () {
+    return constants.RULES
+  }
+}
+exports.AddRuleCommand = AddRuleCommand

--- a/src/codat.js
+++ b/src/codat.js
@@ -4,24 +4,7 @@ const btoa = require('btoa')
 const constants = {
   COMPANIES: 'companies',
   UAT: 'uat',
-  PRODUCTION: 'production',
-  datasets: {
-    BALANCE_SHEET: 'financials/balanceSheet',
-    BILLS: 'bills',
-    CHART_OF_ACCOUNTS: 'accounts',
-    CREDIT_NOTES: 'creditNotes',
-    CUSTOMERS: 'customers',
-    INVOICES: 'invoices',
-    PAYMENTS: 'payments',
-    PROFIT_AND_LOSS: 'financials/profitAndLoss',
-    SUPPLIERS: 'suppliers',
-    BANK_STATEMENTS: 'bankStatements',
-    COMPANY: 'info'
-  },
-  refresh: {
-    ALL: 'all',
-    QUEUE: 'queue'
-  }
+  PRODUCTION: 'production'
 }
 exports.constants = constants
 
@@ -87,6 +70,10 @@ class CodatApiClient {
 
   __companiesBaseUrl (companyId) {
     return `${constants.COMPANIES}/${companyId}`
+  }
+
+  __companyClient () {
+    return this.companiesApi
   }
 
   getCompanies () {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import * as queries from 'codat-queries'
 import * as refresh from 'codat-refresh'
+import * as rules from 'codat-rules'
 
 import {
     uat,
@@ -7,10 +8,7 @@ import {
     apiClient,
     CodatApiClient,
     UpdateCompanySettings,
-    AddCompany,
-    constants } from 'codat'
-
-exports.constants = constants
+    AddCompany } from 'codat'
 
 exports.uat = uat
 exports.production = production
@@ -22,3 +20,4 @@ exports.AddCompany = AddCompany
 
 exports.queries = queries
 exports.refresh = refresh
+exports.rules = rules

--- a/test/constants.test.js
+++ b/test/constants.test.js
@@ -6,7 +6,15 @@ describe('Constants', () => {
     should.exist(constants)
   })
 
-  it('should export datasets constants obect', () => {
-    should.exist(constants.datasets)
+  it('should export companies constant', () => {
+    should.exist(constants.COMPANIES)
+  })
+
+  it('should export uat constant', () => {
+    should.exist(constants.UAT)
+  })
+
+  it('should export production constant', () => {
+    should.exist(constants.PRODUCTION)
   })
 })

--- a/test/queries.test.js
+++ b/test/queries.test.js
@@ -1,6 +1,7 @@
 import should from 'should'
-import { uat, constants } from '../src/codat'
+import { uat } from '../src/codat'
 import {
+    constants,
     BalanceSheetQuery,
     ProfitAndLossQuery,
     AccountsQuery,
@@ -26,8 +27,8 @@ describe('Queries', () => {
     const START_MONTH = new Date();
 
     [
-      [BalanceSheetQuery, constants.datasets.BALANCE_SHEET],
-      [ProfitAndLossQuery, constants.datasets.PROFIT_AND_LOSS]
+      [BalanceSheetQuery, constants.BALANCE_SHEET],
+      [ProfitAndLossQuery, constants.PROFIT_AND_LOSS]
     ].forEach(queryTestParameters => {
       const queryName = queryTestParameters[0].name
       const QueryConstructor = queryTestParameters[0]
@@ -68,13 +69,13 @@ describe('Queries', () => {
     const PAGE_NUMBER = 1;
 
     [
-      [InvoicesQuery, constants.datasets.INVOICES],
-      [CreditNotesQuery, constants.datasets.CREDIT_NOTES],
-      [CustomersQuery, constants.datasets.CUSTOMERS],
-      [SuppliersQuery, constants.datasets.SUPPLIERS],
-      [BillsQuery, constants.datasets.BILLS],
-      [PaymentsQuery, constants.datasets.PAYMENTS],
-      [BankStatementsQuery, constants.datasets.BANK_STATEMENTS]
+      [InvoicesQuery, constants.INVOICES],
+      [CreditNotesQuery, constants.CREDIT_NOTES],
+      [CustomersQuery, constants.CUSTOMERS],
+      [SuppliersQuery, constants.SUPPLIERS],
+      [BillsQuery, constants.BILLS],
+      [PaymentsQuery, constants.PAYMENTS],
+      [BankStatementsQuery, constants.BANK_STATEMENTS]
     ].forEach(queryTestParameters => {
       const queryName = queryTestParameters[0].name
       const QueryConstructor = queryTestParameters[0]
@@ -106,8 +107,8 @@ describe('Queries', () => {
 
   describe('basic', () => {
     [
-      [AccountsQuery, constants.datasets.CHART_OF_ACCOUNTS],
-      [CompanyQuery, constants.datasets.COMPANY]
+      [AccountsQuery, constants.CHART_OF_ACCOUNTS],
+      [CompanyQuery, constants.COMPANY]
     ].forEach(queryTestParameters => {
       const queryName = queryTestParameters[0].name
       const QueryConstructor = queryTestParameters[0]
@@ -132,7 +133,7 @@ describe('Queries', () => {
 
   describe('basic with id', () => {
     [
-        [InvoicePdfQuery, `${constants.datasets.INVOICES}/${INVOICE_ID}/pdf`]
+        [InvoicePdfQuery, `${constants.INVOICES}/${INVOICE_ID}/pdf`]
     ].forEach(queryTestParameters => {
       const queryName = queryTestParameters[0].name
       const QueryConstructor = queryTestParameters[0]

--- a/test/refresh.test.js
+++ b/test/refresh.test.js
@@ -1,6 +1,7 @@
 import should from 'should'
-import { uat, constants } from '../src/codat'
+import { uat } from '../src/codat'
 import {
+    constants,
     RefreshAllDatasets,
     RefreshDataset
  } from '../src/codat-refresh'
@@ -16,7 +17,7 @@ describe('Refresh', () => {
     })
 
     it('should map to the right resource', () => {
-      REFRESH_UNDER_TEST.getResource().should.be.exactly(constants.refresh.ALL)
+      REFRESH_UNDER_TEST.getResource().should.be.exactly(constants.ALL)
     })
   })
 
@@ -28,7 +29,7 @@ describe('Refresh', () => {
     })
 
     it('should map to the right resource', () => {
-      REFRESH_UNDER_TEST.getResource().should.be.exactly(`${constants.refresh.QUEUE}/${DATASET_NAME}`)
+      REFRESH_UNDER_TEST.getResource().should.be.exactly(`${constants.QUEUE}/${DATASET_NAME}`)
     })
   })
 
@@ -41,7 +42,7 @@ describe('Refresh', () => {
     })
 
     it('should mapp to the right resource, with correct data type name', () => {
-      REFRESH_UNDER_TEST.getResource().should.be.exactly(`${constants.refresh.QUEUE}/${DATASET_NAME}`)
+      REFRESH_UNDER_TEST.getResource().should.be.exactly(`${constants.QUEUE}/${DATASET_NAME}`)
     })
   })
 })

--- a/test/rules.test.js
+++ b/test/rules.test.js
@@ -1,0 +1,156 @@
+import should from 'should'
+import {
+  constants,
+  RulesQuery,
+  RuleQuery,
+  AlertsQuery,
+  AlertQuery,
+  AlertsForRuleQuery,
+  AddRuleCommand,
+  DataSyncCompleteRule,
+  NewCompanySynchronised,
+  CurrentAssetsCurrentLiabilitiesRatioRule,
+  DebtorsOutstandingLoanOutstandingRatioRule,
+  CodatRuleOptions
+} from '../src/codat-rules'
+
+describe('Rules', () => {
+  let QUERY_OR_COMMAND_UNDER_TEST = null
+
+  describe('queries', () => {
+    const RULE_ID = constants.DEFAULT_GUID
+    const ALERT_ID = constants.DEFAULT_GUID;
+
+    [
+      [RulesQuery, constants.RULES],
+      [RuleQuery, constants.RULE_WITHID(RULE_ID)],
+      [AlertsQuery, constants.ALERTS],
+      [AlertQuery, constants.ALERT_WITHID(ALERT_ID)],
+      [AlertsForRuleQuery, constants.ALERTS_FORRULE(RULE_ID)]
+    ].forEach(queryTestParameters => {
+      const queryName = queryTestParameters[0].name
+      const QueryConstructor = queryTestParameters[0]
+      const resourceRoute = queryTestParameters[1]
+
+      describe(queryName, () => {
+        beforeEach(() => {
+          QUERY_OR_COMMAND_UNDER_TEST = new QueryConstructor(
+            constants.DEFAULT_GUID
+          )
+        })
+
+        it(`should direct to ${queryName} resource`, () => {
+          QUERY_OR_COMMAND_UNDER_TEST.getResource().should.be.exactly(
+            resourceRoute
+          )
+        })
+
+        it(`should provide ${queryName} argument object`, () => {
+          QUERY_OR_COMMAND_UNDER_TEST.generateArgs().should.eql({})
+        })
+      })
+    })
+  })
+
+  describe('commands', () => {
+    [
+      [DataSyncCompleteRule, 'Data sync completed'],
+      [NewCompanySynchronised, 'New company synchronised'],
+      [CurrentAssetsCurrentLiabilitiesRatioRule, 'CurrentAssetsCurrentLiabilitiesRatio(>,0)'],
+      [DebtorsOutstandingLoanOutstandingRatioRule, 'DebtorsOutstandingLoanOutstandingRatio(>,0)']
+    ].forEach(queryTestParameters => {
+      const ruleName = queryTestParameters[0].name
+      const RuleConstructor = queryTestParameters[0]
+      const type = queryTestParameters[1]
+
+      describe(ruleName, () => {
+        beforeEach(() => {
+          QUERY_OR_COMMAND_UNDER_TEST = new AddRuleCommand(
+            new RuleConstructor(CodatRuleOptions.create())
+          )
+        })
+
+        it(`should direct to ${ruleName} resource`, () => {
+          QUERY_OR_COMMAND_UNDER_TEST.getResource().should.be.exactly(constants.RULES)
+        })
+
+        it(`should create ${ruleName} correct type for model object of rule`, () => {
+          QUERY_OR_COMMAND_UNDER_TEST.generateModel().should.eql({
+            type: type,
+            companyId: null,
+            emails: null,
+            webhook: null
+          })
+        })
+      })
+    })
+  })
+
+  describe('command options', () => {
+    const COMPANY_ID = constants.DEFAULT_GUID
+    const NOTIFY_EMAIL1 = 'hello@world.com'
+    const NOTIFY_EMAIL2 = 'goodbye@world.com'
+    const NOTIFY_WEBHOOK = 'https://web.hook.com/alert';
+
+    [
+      [
+        'Empty',
+        () => CodatRuleOptions.create(),
+        {
+          type: 'Data sync completed',
+          companyId: null,
+          emails: null,
+          webhook: null
+        }
+      ],
+      [
+        'CompanyId',
+        () => CodatRuleOptions.create().withCompany(COMPANY_ID),
+        {
+          type: 'Data sync completed',
+          companyId: COMPANY_ID,
+          emails: null,
+          webhook: null
+        }
+      ],
+      [
+        'Email',
+        () => CodatRuleOptions.create().withEmail(NOTIFY_EMAIL1).withEmail(NOTIFY_EMAIL1).withEmail(NOTIFY_EMAIL2),
+        {
+          type: 'Data sync completed',
+          companyId: null,
+          emails: [NOTIFY_EMAIL1, NOTIFY_EMAIL2],
+          webhook: null
+        }
+      ],
+      [
+        'Webhook',
+        () => CodatRuleOptions.create().withWebHook(NOTIFY_WEBHOOK),
+        {
+          type: 'Data sync completed',
+          companyId: null,
+          emails: null,
+          webhook: NOTIFY_WEBHOOK
+        }
+      ]
+    ].forEach(queryTestParameters => {
+      const ruleName = queryTestParameters[0]
+      const OptionsBuilder = queryTestParameters[1]
+      const EXPECTED_OPTIONS = queryTestParameters[2]
+
+      describe(ruleName, () => {
+        beforeEach(() => {
+          QUERY_OR_COMMAND_UNDER_TEST = new AddRuleCommand(
+            new DataSyncCompleteRule(OptionsBuilder())
+          )
+        })
+
+        it(`should create ${ruleName} options for model object of rule`, () => {
+          QUERY_OR_COMMAND_UNDER_TEST.generateModel().should.eql(
+            EXPECTED_OPTIONS
+          )
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add the rules module and move the constants into the correct modules rather that the base module.

Moving the constants might be a breaking change for anyone still using them with the raw client and not using the `CodatQuery` objects. Have also added new module for `CodatCommands`. Will need to use this more extensively moving forward. 

fixes #9 

